### PR TITLE
Add missing argument to wait-for-clients

### DIFF
--- a/src/kaocha/cljs2/funnel_client.clj
+++ b/src/kaocha/cljs2/funnel_client.clj
@@ -97,7 +97,7 @@
             (when-let [clients (:funnel/clients msg)]
               (reduced clients)))))
 
-(defn wait-for-clients [conn]
+(defn wait-for-clients [conn pred]
   (send conn {:funnel/query client-selector
               :funnel/subscribe client-selector})
   (let [clients (listen conn
@@ -106,6 +106,8 @@
                             (reduced clients)
                             (if-let [whoami (:funnel/whoami msg)]
                               (reduced [whoami]))))
-                        {:timeout false})]
+                        (if pred
+                          pred
+                          {:timeout false}))]
     (send conn {:funnel/unsubscribe client-selector})
     clients))


### PR DESCRIPTION
It appears that the call for wait-for-clients was missing an argument being passed to it, this should correctly accept and pass down that param.