### PR TITLE
Fix chui-remote fixtures :once :after hook

### DIFF
--- a/src/kaocha/type/cljs2.clj
+++ b/src/kaocha/type/cljs2.clj
@@ -183,7 +183,7 @@
                      (assoc var-test ::client client))
         var-tests  (testable/run-testables var-tests test-plan)]
 
-    (send-to client {:type :finish-ns})
+    (send-to client {:type :finish-ns :ns ns})
     (wait-for client :ns-finished timeout)
 
     (t/do-report {:type :end-test-ns})


### PR DESCRIPTION
Send ns with finish-ns to make fixtures :once :after hook work
The ns param is expected here:
https://github.com/lambdaisland/chui/blob/74989be996b3dbcf9c637ba8f93ef8c4a1c5c2c3/modules/chui-remote/src/lambdaisland/chui/remote.cljs#L178-L183