### PR TITLE
fix(example): arity error for `before-hook`

### DIFF
--- a/examples/shadow_cljs_hook.clj
+++ b/examples/shadow_cljs_hook.clj
@@ -37,7 +37,7 @@
         build-config (:shadow.build/config build-state)]
     suite))
 
-(defn before-hook [suite]
+(defn before-hook [suite _]
   (-> suite
       compile-shadow
       launch-browser))


### PR DESCRIPTION
The latest version of kaocha "1.0.732" passes two arguments `suite` and `test-plan` to the hooks https://cljdoc.org/d/lambdaisland/kaocha/1.0.732/doc/plugin-hooks

<!--

Thank you for your contribution! Please also think about (where applicable)

- the CHANGELOG, you can add an entry at the top underneath "Unreleased"
- the README and other documentation
- the tests, at least run them yourself before submitting (usually a `bin/kaocha` will do)

-->
