### PR TITLE
Upgrade kaocha version to 1.70.1086

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ## Changed
 
+- Upgrade Kaocha to 1.70.1086
+
 # 0.0.35 (2020-10-02 / 3a506bd)
 
 ## Fixed

--- a/deps.edn
+++ b/deps.edn
@@ -20,7 +20,7 @@
 
   :test
   {:extra-paths ["test"]
-   :extra-deps  {lambdaisland/kaocha {:mvn/version "1.0.672"}
+   :extra-deps  {lambdaisland/kaocha {:mvn/version "1.70.1086"}
                  aleph/aleph {:mvn/version "0.4.2"}
                  org.apache.tika/tika-core {:mvn/version "1.17"}
                  io.netty/netty-all {:mvn/version "4.1.34.Final"}

--- a/src/kaocha/cljs2/print_handlers.clj
+++ b/src/kaocha/cljs2/print_handlers.clj
@@ -1,6 +1,6 @@
 (ns kaocha.cljs2.print-handlers
-  (:require [lambdaisland.deep-diff.printer :as printer]
-            [puget.printer :as puget]))
+  (:require [lambdaisland.deep-diff2.printer-impl :as printer]
+            [lambdaisland.deep-diff2.puget.printer :as puget]))
 
 (printer/register-print-handler!
  'com.cognitect.transit.impl.TaggedValueImpl


### PR DESCRIPTION
Do we want to bump kaocha to the most recent version?

Fixes #16
<!--

Thank you for your contribution! Please also think about (where applicable)

- the CHANGELOG, you can add an entry at the top underneath "Unreleased"
- the README and other documentation
- the tests, at least run them yourself before submitting (usually a `bin/kaocha` will do)

-->
