### PR TITLE
Upgrade chui, fix incompatibility with current CLJS compiler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ## Fixed
 
+- Upgrade Chui, fixes a glogi dependency incompatibility with current version of Clojurescript
+
 ## Changed
 
 # 0.0.35 (2020-10-02 / 3a506bd)

--- a/deps.edn
+++ b/deps.edn
@@ -1,8 +1,8 @@
 {:paths ["src" "resources"]
 
  :deps
- {lambdaisland/chui-remote {:mvn/version "0.0.156"}
-  lambdaisland/chui-ui     {:mvn/version "0.0.156"}
+ {lambdaisland/chui-remote {:mvn/version "1.1.192"}
+  lambdaisland/chui-ui     {:mvn/version "1.1.192"}
   io.pedestal/pedestal.log {:mvn/version "0.5.8"}}
 
  :aliases


### PR DESCRIPTION
The previous version of chui was using a glogi version that caused a compilation error with the most recent version of the CLJS compiler.

Before:
![2022-10-07-14:58:43-screenshot](https://user-images.githubusercontent.com/22163194/194672426-a165d152-87a0-4c00-b58a-b0a8071383b6.png)


After:
![2022-10-07-15:25:46-screenshot](https://user-images.githubusercontent.com/22163194/194672387-93392d99-9383-4d6c-aa2d-3178e56aa5e3.png)

Fixes #14 
<!--

Thank you for your contribution! Please also think about (where applicable)

- the CHANGELOG, you can add an entry at the top underneath "Unreleased"
- the README and other documentation
- the tests, at least run them yourself before submitting (usually a `bin/kaocha` will do)

-->
