### PR TITLE
Use correct :aliases-as-optional-deps, :test.

### DIFF
--- a/bin/proj
+++ b/bin/proj
@@ -7,7 +7,7 @@
  {:license        :mpl
   :inception-year 2020
   :description    "cljs.test support for Kaocha, second generation."
-  :aliases-as-optional-deps  [:dev]
+  :aliases-as-optional-deps  [:test]
   :group-id "lambdaisland"
   })
 


### PR DESCRIPTION
:test includes Kaocha itself, which is a BYOD (bring your own dependency) that needs to be specified as optional for Cljdoc to be able to dynamically analyze the namespaces for API docstrings. I specified :dev by mistake.
